### PR TITLE
remove kwargs from the return value of 'event()'

### DIFF
--- a/asynckivy/__init__.py
+++ b/asynckivy/__init__.py
@@ -48,7 +48,7 @@ def event(ed, name, *, filter=None, return_value=None):
         step_coro(*args, **kwargs)
         return return_value
 
-    return (yield bind)
+    return (yield bind)[0]
 
 
 async def thread(func, *args, **kwargs):

--- a/examples/how_to_use_return_value_argument.py
+++ b/examples/how_to_use_return_value_argument.py
@@ -35,18 +35,16 @@ class TestApp(App):
         async def handle_touch(widget):
             event = asynckivy.event
             while True:
-                args, kwargs = await event(
+                __, touch = await event(
                     widget, 'on_touch_down',
                     filter=lambda w, touch: w.collide_point(*touch.opos) and touch.button == 'left')
                 print('start drawing poly-line')
-                touch = args[1]
                 with widget.canvas:
                     Color(*get_random_color())
                     line = Line(points=[*touch.opos], width=2)
                 while True:
-                    args, kwargs = await event(
+                    __, touch = await event(
                         widget, 'on_touch_down', return_value=True)
-                    touch = args[1]
                     if touch.button == 'left':
                         line.points.extend(touch.pos)
                         line.points = line.points

--- a/examples/using_event_parameter.py
+++ b/examples/using_event_parameter.py
@@ -15,8 +15,7 @@ class TestApp(App):
             await sleep(2)
             while True:
                 label.text = 'Touch anywhere'
-                args, kwargs = await event(label, 'on_touch_down')
-                touch = args[1]
+                __, touch = await event(label, 'on_touch_down')
                 opos = label.to_window(*touch.opos)
                 label.text = 'You touched at ' + str(tuple(int(v) for v in opos))
                 await sleep(1)


### PR DESCRIPTION
The following code is how we currently receive event's arguments:

```python
args, kwargs = await event(widget, 'on_touch_down')
touch = args[1]
print(f"You touched at {touch.opos}")
```

but since all existing events don't use kwargs at all, I think it's better to remove it from the return value. So we can write like this:

```python
__, touch = await event(widget, 'on_touch_down')
print(f"You touched at {touch.opos}")
```