### PR TITLE
Tune 'rest_of_touch_moves()'

### DIFF
--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -10,6 +10,10 @@ async def rest_of_touch_moves(widget, touch, *, eats_touch=False):
     dispatched further.
     '''
     from asynckivy._core import _get_step_coro
+
+    if touch.time_end != -1:
+        raise ValueError(f"the touch already has ended")
+
     step_coro = await _get_step_coro()
 
     if eats_touch:

--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -19,25 +19,25 @@ async def rest_of_touch_moves(
             if t is touch:
                 if t.grab_current is w:
                     t.ungrab(w)
-                    step_coro(True)
+                    step_coro(False)
                 return True
     else:
         def _on_touch_up(w, t):
             if t.grab_current is w and t is touch:
                 t.ungrab(w)
-                step_coro(True)
+                step_coro(False)
                 return True
 
     if eats_touch_move:
         def _on_touch_move(w, t):
             if t is touch:
                 if t.grab_current is w:
-                    step_coro(False)
+                    step_coro(True)
                 return True
     else:
         def _on_touch_move(w, t):
             if t.grab_current is w and t is touch:
-                step_coro(False)
+                step_coro(True)
                 return True
 
     touch.grab(widget)
@@ -47,13 +47,11 @@ async def rest_of_touch_moves(
     assert uid_move
 
     # assigning to a local variable might improve performance
-    true_if_touch_up_false_if_touch_move = \
-        _true_if_touch_up_false_if_touch_move
+    true_if_touch_move_false_if_touch_up = \
+        _true_if_touch_move_false_if_touch_up
 
     try:
-        while True:
-            if await true_if_touch_up_false_if_touch_move():
-                return
+        while await true_if_touch_move_false_if_touch_up():
             yield touch
     finally:
         widget.unbind_uid('on_touch_up', uid_up)
@@ -61,7 +59,7 @@ async def rest_of_touch_moves(
 
 
 @types.coroutine
-def _true_if_touch_up_false_if_touch_move() -> bool:
+def _true_if_touch_move_false_if_touch_up() -> bool:
     return (yield lambda step_coro: None)[0][0]
 
 

--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -49,6 +49,7 @@ async def rest_of_touch_moves(widget, touch, *, eats_touch=False):
         while await true_if_touch_move_false_if_touch_up():
             yield touch
     finally:
+        touch.ungrab(widget)
         widget.unbind_uid('on_touch_up', uid_up)
         widget.unbind_uid('on_touch_move', uid_move)
 

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -14,25 +14,24 @@ def touch_cls():
     return Touch
 
 
-@pytest.mark.parametrize('n_touch_move', [0, 1, 10])
-def test_a_number_of_on_touch_move_fired(touch_cls, n_touch_move):
+@pytest.mark.parametrize('n_touch_moves', [0, 1, 10])
+def test_a_number_of_on_touch_moves_fired(touch_cls, n_touch_moves):
     from time import perf_counter
     from kivy.uix.widget import Widget
     import asynckivy as ak
 
     async def _test(w, t):
-        from asynckivy import rest_of_touch_moves 
         n = 0
-        async for __ in rest_of_touch_moves(w, t):
+        async for __ in ak.rest_of_touch_moves(w, t):
             n += 1
-        assert n == n_touch_move
+        assert n == n_touch_moves
         nonlocal done;done = True
         
     done = False
     w = Widget()
     t = touch_cls()
     ak.start(_test(w, t))
-    for __ in range(n_touch_move):
+    for __ in range(n_touch_moves):
         w.dispatch('on_touch_move', t)
     w.dispatch('on_touch_up', t)
     assert done
@@ -43,31 +42,30 @@ def test_break_during_a_for_loop(touch_cls):
     import asynckivy as ak
 
     async def _test(w, t):
-        from asynckivy import rest_of_touch_moves, event
-        nonlocal n
-        async for __ in rest_of_touch_moves(w, t):
-            n += 1
-            if n == 2:
+        nonlocal n_touch_moves
+        async for __ in ak.rest_of_touch_moves(w, t):
+            n_touch_moves += 1
+            if n_touch_moves == 2:
                 break
-        await event(w, 'on_touch_up')
+        await ak.event(w, 'on_touch_up')
         nonlocal done;done = True
 
-    n = 0
+    n_touch_moves = 0
     done = False
     w = Widget()
     t = touch_cls()
     ak.start(_test(w, t))
     w.dispatch('on_touch_move', t)
-    assert n == 1
+    assert n_touch_moves == 1
     assert not done
     w.dispatch('on_touch_move', t)
-    assert n == 2
+    assert n_touch_moves == 2
     assert not done
     w.dispatch('on_touch_move', t)
-    assert n == 2
+    assert n_touch_moves == 2
     assert not done
     w.dispatch('on_touch_up', t)
-    assert n == 2
+    assert n_touch_moves == 2
     assert done
 
 
@@ -83,8 +81,7 @@ def test_eat_touch_events(touch_cls, eats_touch_move, eats_touch_up, expectation
     import asynckivy as ak
 
     async def _test(parent, t):
-        from asynckivy import rest_of_touch_moves 
-        async for __ in rest_of_touch_moves(
+        async for __ in ak.rest_of_touch_moves(
                 parent, t,
                 eats_touch_move=eats_touch_move,
                 eats_touch_up=eats_touch_up):

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -70,21 +70,17 @@ def test_break_during_a_for_loop(touch_cls):
 
 
 @pytest.mark.parametrize(
-    'eats_touch_move, eats_touch_up, expectation', [
-        (True, True, [0, 0, 0, ], ),
-        (True, False, [0, 0, 1, ], ),
-        (False, True, [1, 2, 0, ], ),
-        (False, False, [1, 2, 1, ], ),
+    'eats_touch, expectation', [
+        (True, [0, 0, 0, ], ),
+        (False, [1, 2, 1, ], ),
     ])
-def test_eat_touch_events(touch_cls, eats_touch_move, eats_touch_up, expectation):
+def test_eat_touch_events(touch_cls, eats_touch, expectation):
     from kivy.uix.widget import Widget
     import asynckivy as ak
 
     async def _test(parent, t):
         async for __ in ak.rest_of_touch_moves(
-                parent, t,
-                eats_touch_move=eats_touch_move,
-                eats_touch_up=eats_touch_up):
+                parent, t, eats_touch=eats_touch):
             pass
         nonlocal done;done = True
 

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -5,10 +5,11 @@ import pytest
 def touch_cls():
     import weakref
     class Touch:
-        __slots__ = ('grab_current', 'grab_list', )
+        __slots__ = ('grab_current', 'grab_list', 'time_end', )
         def __init__(self):
             self.grab_current = None
             self.grab_list = []
+            self.time_end = -1
         def grab(self, w):
             self.grab_list.append(weakref.ref(w.__self__))
         def ungrab(self, w):

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -32,7 +32,13 @@ def test_a_number_of_on_touch_moves_fired(touch_cls, n_touch_moves):
     t = touch_cls()
     ak.start(_test(w, t))
     for __ in range(n_touch_moves):
+        t.grab_current = None
         w.dispatch('on_touch_move', t)
+        t.grab_current = w
+        w.dispatch('on_touch_move', t)
+    t.grab_current = None
+    w.dispatch('on_touch_up', t)
+    t.grab_current = w
     w.dispatch('on_touch_up', t)
     assert done
 
@@ -55,15 +61,16 @@ def test_break_during_a_for_loop(touch_cls):
     w = Widget()
     t = touch_cls()
     ak.start(_test(w, t))
-    w.dispatch('on_touch_move', t)
-    assert n_touch_moves == 1
-    assert not done
-    w.dispatch('on_touch_move', t)
-    assert n_touch_moves == 2
-    assert not done
-    w.dispatch('on_touch_move', t)
-    assert n_touch_moves == 2
-    assert not done
+    for expected in (1, 2, 2, ):
+        t.grab_current = None
+        w.dispatch('on_touch_move', t)
+        t.grab_current = w
+        w.dispatch('on_touch_move', t)
+        assert n_touch_moves == expected
+        assert not done
+    t.grab_current = None
+    w.dispatch('on_touch_up', t)
+    t.grab_current = w
     w.dispatch('on_touch_up', t)
     assert n_touch_moves == 2
     assert done


### PR DESCRIPTION
### about breaking change

```python3
async for __ in rest_of_touch_moves(w, t, eats_touch_move=True, eats_touch_up=True):
   ...
```

`eats_touch_move` and `eats_touch_up` aren't available anymore. Instead, use `eats_touch`, which is equivalent to using `eats_touch_move` and `eats_touch_up` at once.