### PR TITLE
Enable a coroutine to get the root coroutine

### DIFF
--- a/asynckivy/_core.py
+++ b/asynckivy/_core.py
@@ -17,6 +17,9 @@ def start(coro):
                 coro.send((args, kwargs, ))(step_coro)
         except StopIteration:
             pass
+    step_coro.ctx = {
+        'root_coro': coro,
+    }
 
     try:
         coro.send(None)(step_coro)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,41 @@
 import pytest
 
 
+def test_get_the_root_coroutine_from_a_root_coroutine_itself():
+    import asynckivy as ak
+    root_coro = None
+    done = False
+
+    async def root_async_fn():
+        from asynckivy._core import _get_step_coro
+        step_coro = await _get_step_coro()
+        assert root_coro is step_coro.ctx['root_coro']
+        nonlocal done; done = True
+
+    root_coro = root_async_fn()
+    ak.start(root_coro)
+    assert done
+
+
+def test_get_the_root_coroutine_from_its_child():
+    import asynckivy as ak
+    root_coro = None
+    done = False
+
+    async def root_async_fn():
+        await child_async_fn()
+
+    async def child_async_fn():
+        from asynckivy._core import _get_step_coro
+        step_coro = await _get_step_coro()
+        assert root_coro is step_coro.ctx['root_coro']
+        nonlocal done; done = True
+
+    root_coro = root_async_fn()
+    ak.start(root_coro)
+    assert done
+
+
 def test_gather():
     import asynckivy as ak
     from asynckivy._core import gather


### PR DESCRIPTION
`asyncio.current_task().get_coro()`に相当する機能の実現。関数である`step_coro`に属性を加えてそこに`最も外側のcoroutine`を格納するというのは奇妙な実装ですが、既存の設計を壊さずになおかつglobal変数を用いない方法として私にはこれしか思い浮かばなかったので仕方がない。ただこれはあくまで内部用の物で`asynckivy`の利用者が触るべき物じゃないので大した問題ではない。