### PR TITLE
Have 'run_in_thread()' propagate an uncaught exception to its caller

### DIFF
--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_propagate_an_uncaught_exception_to_the_caller():
+    import time
+    from kivy.clock import Clock
+    import asynckivy as ak
+
+    def impolite_func():
+        return 1 / 0
+
+    async def job():
+        with pytest.raises(ZeroDivisionError):
+            await ak.run_in_thread(impolite_func, polling_interval=.1)
+        nonlocal done; done = True
+
+    done = False
+    ak.start(job())
+    time.sleep(.2)
+    Clock.tick()
+    assert done


### PR DESCRIPTION
## Before this PR

When you are waiting for the completion of another thread by using `run_in_thread()`, if an uncaught exception occured in that thread, the caller stops there forever.

```python
from kivy.app import App
from kivy.uix.widget import Widget
import asynckivy as ak


class SampleApp(App):
    def build(self):
        return Widget()

    def on_start(self):
        def impolite_func():
            return 1 / 0

        async def async_main():
            await ak.run_in_thread(impolite_func, polling_interval=1)  # stops here forever
            print("This line never be excuted")

        ak.start(async_main())


if __name__ == '__main__':
    SampleApp().run()
```

```
 Exception in thread Thread-7:
 Traceback (most recent call last):
   File "<omitted>/.pyenv/versions/3.7.1/lib/python3.7/threading.py", line 917, in _bootstrap_inner
     self.run()
   File "<omitted>/.pyenv/versions/3.7.1/lib/python3.7/threading.py", line 865, in run
     self._target(*self._args, **self._kwargs)
   File "<omitted>/asynckivy/_threading.py", line 13, in wrapper
     return_value = func()
   File "<omitted>/example.py", line 12, in impolite_func
     return 1 / 0
 ZeroDivisionError: division by zero
```

You can see the error from `impolite_func()` in the console, but the caller coroutine cannot notice the exception, and waits forever.

## After this PR

After the PR, the caller coroutine can notice to an uncaught exception, and has the opportunity to handle it.

```python
from kivy.app import App
from kivy.uix.widget import Widget
import asynckivy as ak


class SampleApp(App):
    def build(self):
        return Widget()

    def on_start(self):
        def impolite_func():
            return 1 / 0

        async def async_main():
            try:
                await ak.run_in_thread(impolite_func, polling_interval=1)
            except ZeroDivisionError:
                print("Don't divide by 0!")

        ak.start(async_main())


if __name__ == '__main__':
    SampleApp().run()
```

```
Don't divide by 0!
```