### PR TITLE
rename some keyword arguments to 'stop_dispatching'

### DIFF
--- a/asynckivy/_event.py
+++ b/asynckivy/_event.py
@@ -4,7 +4,7 @@ import types
 
 
 @types.coroutine
-def event(ed, name, *, filter=None, return_value=None):
+def event(ed, name, *, filter=None, stop_dispatching=False):
     '''
     event
     =====
@@ -50,7 +50,7 @@ def event(ed, name, *, filter=None, return_value=None):
                    widget, 'x',
                    filter=lambda widget, x: x > 100)
 
-    ``return_value`` is useful when you want to stop event-dispatching.
+    ``stop_dispatching`` is useful when you want to stop event-dispatching.
 
     .. code-block:: python
 
@@ -60,7 +60,7 @@ def event(ed, name, *, filter=None, return_value=None):
            # wait for a label to get touched inside of it, and stop the
            # event-dispatching when it happened.
            await ak.event(
-               label, 'on_touch_down', return_value=True,
+               label, 'on_touch_down', stop_dispatching=True,
                filter=lambda label, touch: label.collide_point(*touch.opos),
            )
     '''
@@ -78,6 +78,6 @@ def event(ed, name, *, filter=None, return_value=None):
             return
         ed.unbind_uid(name, bind_id)
         step_coro(*args, **kwargs)
-        return return_value
+        return stop_dispatching
 
     return (yield bind)[0]

--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -3,10 +3,10 @@ __all__ = ('rest_of_touch_moves', )
 import types
 
 
-async def rest_of_touch_moves(widget, touch, *, eat_touch=False):
+async def rest_of_touch_moves(widget, touch, *, stop_dispatching=False):
     '''Returns an async-generator that yields the given touch when
     `on_touch_move` is fired, and ends when `on_touch_up` is fired. Grabs and
-    ungrabs the touch automatically. If `eat_touch` is True, the touch
+    ungrabs the touch automatically. If `stop_dispatching` is True, the touch
     will never be dispatched further i.e. the next widget will never get this
     touch until the generator ends. If `on_touch_up` was already fired,
     `MotionEventAlreadyEndedError` will be raised.
@@ -28,7 +28,7 @@ async def rest_of_touch_moves(widget, touch, *, eat_touch=False):
         else:
             return
 
-    if eat_touch:
+    if stop_dispatching:
         def _on_touch_up(w, t):
             if t is touch:
                 if t.grab_current is w:

--- a/examples/painter.py
+++ b/examples/painter.py
@@ -36,7 +36,8 @@ class Painter(RelativeLayout):
         inst_group.add(line)
         ox, oy = self.to_local(*touch.opos)
         on_touch_move_was_fired = False
-        async for __ in ak.rest_of_touch_moves(self, touch):
+        async for __ in ak.rest_of_touch_moves(
+                self, touch, stop_dispatching=True):
             # Don't await anything during the iteration
             on_touch_move_was_fired = True
             x, y = self.to_local(*touch.pos)

--- a/examples/painter2.py
+++ b/examples/painter2.py
@@ -34,7 +34,8 @@ class Painter(RelativeLayout):
             inst_group.add(line)
             ox, oy = self.to_local(*touch.opos)
             on_touch_move_was_fired = False
-            async for __ in rest_of_touch_moves(self, touch):
+            async for __ in rest_of_touch_moves(
+                    self, touch, stop_dispatching=True):
                 # Don't await anything during the iteration
                 on_touch_move_was_fired = True
                 x, y = self.to_local(*touch.pos)

--- a/examples/painter2.py
+++ b/examples/painter2.py
@@ -26,7 +26,7 @@ class Painter(RelativeLayout):
         while True:
             __, touch = await event(
                 self, 'on_touch_down', filter=will_accept_touch,
-                return_value=True)
+                stop_dispatching=True)
             inst_group = InstructionGroup()
             self.canvas.add(inst_group)
             inst_group.add(Color(*get_random_color()))

--- a/examples/springy_button.py
+++ b/examples/springy_button.py
@@ -80,7 +80,8 @@ class SpringyButton(Label):
                 stop_dispatching=True)
             self.dispatch('on_press')
             blink_ev()
-            async for __ in rest_of_touch_moves(self, touch):
+            async for __ in rest_of_touch_moves(
+                    self, touch, stop_dispatching=True):
                 if self.collide_point(*touch.pos):
                     blink_ev()
                 else:

--- a/examples/springy_button.py
+++ b/examples/springy_button.py
@@ -77,7 +77,7 @@ class SpringyButton(Label):
         while True:
             __, touch = await event(
                 self, 'on_touch_down', filter=will_accept_touch,
-                return_value=True)
+                stop_dispatching=True)
             self.dispatch('on_press')
             blink_ev()
             async for __ in rest_of_touch_moves(self, touch):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -76,11 +76,11 @@ def test_filter(ed):
     assert done
 
 
-def test_return_value(ed):
+def test_stop_dispatching(ed):
     import asynckivy as ak
     async def _test():
         await ak.event(ed, 'on_test')
-        await ak.event(ed, 'on_test', return_value=True)
+        await ak.event(ed, 'on_test', stop_dispatching=True)
         await ak.event(ed, 'on_test')
         nonlocal done;done = True
     done = False

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -88,17 +88,17 @@ def test_break_during_a_for_loop(touch_cls):
 
 
 @pytest.mark.parametrize(
-    'eat_touch, expectation', [
+    'stop_dispatching, expectation', [
         (True, [0, 0, 0, ], ),
         (False, [1, 2, 1, ], ),
     ])
-def test_eat_touch_events(touch_cls, eat_touch, expectation):
+def test_stop_dispatching(touch_cls, stop_dispatching, expectation):
     from kivy.uix.widget import Widget
     import asynckivy as ak
 
     async def _test(parent, t):
         async for __ in ak.rest_of_touch_moves(
-                parent, t, eat_touch=eat_touch):
+                parent, t, stop_dispatching=stop_dispatching):
             pass
         nonlocal done;done = True
 


### PR DESCRIPTION
### before

```python
def event(ed, name, *, filter=None, return_value=None):
    ...

async def rest_of_touch_moves(widget, touch, *, eat_touch=False):
    ...
```

### after

```python
def event(ed, name, *, filter=None, stop_dispatching=False):
    ...

async def rest_of_touch_moves(widget, touch, *, stop_dispatching=False):
    ...
```