### PR TITLE
add structured version of 'or_()' and 'and_()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 pip install asynckivy
 ```
 
-```
-# development version
-pip install git+https://github.com/gottadiveintopython/asynckivy.git@master#egg=asynckivy
-```
+## Pin the minor version
+
+If you use this module, it's recommended to pin the minor version, because if
+it changed, it usually means some breaking changes occurred.
 
 ## Usage
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -9,10 +9,11 @@
 pip install asynckivy
 ```
 
-```
-# development version
-pip install git+https://github.com/gottadiveintopython/asynckivy.git@master#egg=asynckivy
-```
+## このmoduleを使う際の注意点
+
+このmoduleのminor versionが変わった時は何らかの互換性の無い変更が加えられた可能性が
+高いので、このmoduleを使う際はminor versionを固定してください。少なくともmajor version
+が0の間はminor versionが互換性の目安となっています。
 
 ## 使い方
 

--- a/asynckivy/__init__.py
+++ b/asynckivy/__init__.py
@@ -8,3 +8,4 @@ from ._rest_of_touch_moves import *
 from ._threading import *
 from ._start_soon import *
 from ._close_soon import *
+from ._or_and import *

--- a/asynckivy/_or_and.py
+++ b/asynckivy/_or_and.py
@@ -1,0 +1,64 @@
+__all__ = ('and_', 'or_', 'and_from_iterable', 'or_from_iterable', )
+
+import types
+from typing import Iterable, List
+from asyncgui import Task, Awaitable_or_Task
+
+
+@types.coroutine
+def _gather(aws_and_tasks: Iterable[Awaitable_or_Task], *, n: int = None) \
+        -> List[Task]:
+    '''(internal)'''
+    from asynckivy import start, close_soon
+
+    def do_nothing():
+        pass
+
+    tasks = [v if isinstance(v, Task) else Task(v) for v in aws_and_tasks]
+    n_tasks = len(tasks)
+    n_left = n_tasks if n is None else min(n, n_tasks)
+    step_coro = do_nothing
+
+    def done_callback(*args, **kwargs):
+        nonlocal n_left
+        n_left -= 1
+        if n_left == 0:
+            step_coro()
+
+    try:
+        for task in tasks:
+            task._event.add_callback(done_callback)
+            start(task)
+
+        if n_left <= 0:
+            return tasks
+
+        def callback(step_coro_):
+            nonlocal step_coro
+            step_coro = step_coro_
+        yield callback
+
+        return tasks
+    finally:
+        step_coro = do_nothing
+        for task in tasks:
+            if task.is_cancellable:
+                task.cancel()
+            else:
+                close_soon(task)
+
+
+async def or_(*aws_and_tasks: Iterable[Awaitable_or_Task]):
+    return await _gather(aws_and_tasks, n=1)
+
+
+async def or_from_iterable(aws_and_tasks: Iterable[Awaitable_or_Task]):
+    return await _gather(aws_and_tasks, n=1)
+
+
+async def and_(*aws_and_tasks: Iterable[Awaitable_or_Task]):
+    return await _gather(aws_and_tasks)
+
+
+async def and_from_iterable(aws_and_tasks: Iterable[Awaitable_or_Task]):
+    return await _gather(aws_and_tasks)

--- a/tests/test_or_and.py
+++ b/tests/test_or_and.py
@@ -1,0 +1,57 @@
+import pytest
+
+class Test_and_:
+    def test_cancel_root(self):
+        import asynckivy as ak
+        TS = ak.TaskState
+
+        tasks = [ak.Task(ak.sleep_forever()) for __ in range(3)]
+        root = ak.start(ak.and_from_iterable(tasks))
+        for task in tasks:
+            assert task.state == TS.STARTED
+        root.close()
+        for task in tasks:
+            assert task.state == TS.CANCELLED
+
+
+class Test_or_:
+    def test_normal(self):
+        import asynckivy as ak
+        TS = ak.TaskState
+
+        e = ak.Event()
+        tasks = [
+            ak.Task(v) for v in
+            (*(ak.sleep_forever() for __ in range(3)), e.wait())
+        ]
+        ak.start(ak.or_from_iterable(tasks))
+        for task in tasks:
+            assert task.state == TS.STARTED
+        e.set()
+        for task in tasks[:-1]:
+            assert task.state == TS.CANCELLED
+        tasks[-1].state == TS.DONE
+
+    def test_cancel(self):
+        import asynckivy as ak
+        TS = ak.TaskState
+
+        tasks = [ak.Task(ak.sleep_forever()) for __ in range(3)]
+        ak.start(ak.or_from_iterable(tasks))
+        for task in tasks:
+            assert task.state == TS.STARTED
+        tasks[1].close()
+        for task in tasks:
+            assert task.state == TS.CANCELLED
+
+    def test_cancel_root(self):
+        import asynckivy as ak
+        TS = ak.TaskState
+
+        tasks = [ak.Task(ak.sleep_forever()) for __ in range(3)]
+        root = ak.start(ak.or_from_iterable(tasks))
+        for task in tasks:
+            assert task.state == TS.STARTED
+        root.close()
+        for task in tasks:
+            assert task.state == TS.CANCELLED


### PR DESCRIPTION
Automatically cancels child tasks.

## before the PR

```python
import asynckivy as ak
TS = ak.TaskState

tasks = [ak.Task(ak.sleep_forever()) for __ in range(3)]

async def test():
    await ak.or_from_iterable(tasks)

ak.start(test())
tasks[1].cancel()
assert tasks[0].state == TS.STARTED
assert tasks[1].state == TS.CANCELLED
assert tasks[2].state == TS.STARTED
```

## after the PR

```python
import asynckivy as ak
TS = ak.TaskState

tasks = [ak.Task(ak.sleep_forever()) for __ in range(3)]

async def test():
    await ak.or_from_iterable(tasks)

ak.start(test())
tasks[1].cancel()
for task in tasks:
    assert task.state == TS.CANCELLED
```