### PR TITLE
have 'rest_of_touch_moves()' wait for enough time to capture simulated 'on_touch_up'

### DIFF
--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -3,27 +3,25 @@ __all__ = ('rest_of_touch_moves', )
 import types
 
 
-async def rest_of_touch_moves(widget, touch, *, stop_dispatching=False):
-    '''Returns an async-generator that yields the given touch when
+async def rest_of_touch_moves(
+        widget, touch, *, stop_dispatching=False, timeout=1.):
+    '''
+    Returns an async-generator that iterates the number of times
     `on_touch_move` is fired, and ends when `on_touch_up` is fired. Grabs and
     ungrabs the touch automatically. If `stop_dispatching` is True, the touch
     will never be dispatched further i.e. the next widget will never get this
     touch until the generator ends. If `on_touch_up` was already fired,
     `MotionEventAlreadyEndedError` will be raised.
     '''
-    from asyncgui import get_step_coro
-    from asynckivy import or_, sleep, event
-    from asynckivy.exceptions import MotionEventAlreadyEndedError
+    from asynckivy import (
+        or_, sleep, event, get_step_coro, MotionEventAlreadyEndedError,
+    )
 
-    step_coro = await get_step_coro()
     if touch.time_end != -1:
-        # `on_touch_up` might be already fired. If so raise an exception.
+        # `on_touch_up` might have been already fired so we need to find out
+        # it actually was or not.
         tasks = await or_(
-            # If a widget like ScrollView is in the parent-stack,
-            # touch events are simulated and delayed than the real ones.
-            # So we need to wait for enough time before we decide whether
-            # to raise a MotionEventAlreadyEndedError or not.
-            sleep(1.),
+            sleep(timeout),
             event(widget, 'on_touch_up', filter=lambda w, t: t is touch),
         )
         if tasks[0].done:
@@ -32,6 +30,7 @@ async def rest_of_touch_moves(widget, touch, *, stop_dispatching=False):
         else:
             return
 
+    step_coro = await get_step_coro()
     if stop_dispatching:
         def _on_touch_up(w, t):
             if t is touch:

--- a/asynckivy/_rest_of_touch_moves.py
+++ b/asynckivy/_rest_of_touch_moves.py
@@ -19,7 +19,11 @@ async def rest_of_touch_moves(widget, touch, *, stop_dispatching=False):
     if touch.time_end != -1:
         # `on_touch_up` might be already fired. If so raise an exception.
         tasks = await or_(
-            sleep(0),
+            # If a widget like ScrollView is in the parent-stack,
+            # touch events are simulated and delayed than the real ones.
+            # So we need to wait for enough time before we decide whether
+            # to raise a MotionEventAlreadyEndedError or not.
+            sleep(1.),
             event(widget, 'on_touch_up', filter=lambda w, t: t is touch),
         )
         if tasks[0].done:

--- a/tests/test_rest_of_touch_moves.py
+++ b/tests/test_rest_of_touch_moves.py
@@ -150,6 +150,7 @@ def test_the_touch_that_might_already_ended(touch_cls, actually_ended):
     task = ak.start(job(w, t))
 
     if actually_ended:
+        time.sleep(2.)
         Clock.tick()
     else:
         t.grab_current = None


### PR DESCRIPTION
Widget like `ScrollView`  simulates touch events when a touch is not a scrolling-gesture.
When that happens, the simulated touch events quite delay (depending on the situation), which makes `rest_of_touch_moves()`  misrecognize a simulated-ongoing-touch as already ended, which causes `MotionEventAlreadyEnded` to occur unnecessarily.

This PR fix that by having `rest_of_touch_moves()` wait for enough time to capture a simulated `on_touch_up`.