### PR TITLE
add n_frames() : wait for specified number of frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ async def some_task(button):
     dt = await ak.sleep(1)
     print(f'{dt} seconds have passed')
 
-    # wait for two frames
-    await ak.n_frames(2)
-
     # wait until a button is pressed
     await ak.event(button, 'on_press')
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ async def some_task(button):
     # wait for 1sec
     dt = await ak.sleep(1)
     print(f'{dt} seconds have passed')
-    
+
+    # wait for two frames
+    await ak.n_frames(2)
+
     # wait until a button is pressed
     await ak.event(button, 'on_press')
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -73,7 +73,10 @@ async def some_task(button):
     # 1秒待つ
     dt = await ak.sleep(1)
     print(f'{dt}秒経ちました')
-    
+
+    # 2frame 待つ
+    await ak.n_frames(2)
+
     # buttonが押されるまで待つ
     await ak.event(button, 'on_press')
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -74,9 +74,6 @@ async def some_task(button):
     dt = await ak.sleep(1)
     print(f'{dt}秒経ちました')
 
-    # 2frame 待つ
-    await ak.n_frames(2)
-
     # buttonが押されるまで待つ
     await ak.event(button, 'on_press')
 

--- a/asynckivy/_sleep.py
+++ b/asynckivy/_sleep.py
@@ -1,4 +1,4 @@
-__all__ = ('sleep', 'sleep_free', 'create_sleep', )
+__all__ = ('sleep', 'sleep_free', 'create_sleep', 'n_frames', )
 
 import types
 
@@ -62,3 +62,9 @@ async def create_sleep(duration):
     def sleep():
         return (yield clock_event)[0][0]
     return sleep
+
+
+async def n_frames(n: int):
+    sleep_for_1frame = await create_sleep(0)
+    for __ in range(n):
+        await sleep_for_1frame()

--- a/asynckivy/_sleep.py
+++ b/asynckivy/_sleep.py
@@ -65,6 +65,7 @@ async def create_sleep(duration):
 
 
 async def n_frames(n: int):
+    '''(experimental)'''
     sleep_for_1frame = await create_sleep(0)
     for __ in range(n):
         await sleep_for_1frame()

--- a/asynckivy/_sleep.py
+++ b/asynckivy/_sleep.py
@@ -66,6 +66,8 @@ async def create_sleep(duration):
 
 async def n_frames(n: int):
     '''(experimental)'''
+    if n < 0:
+        raise ValueError("Cannot await negative number of frames")
     sleep_for_1frame = await create_sleep(0)
     for __ in range(n):
         await sleep_for_1frame()

--- a/examples/changing_text_with_fade_transition.py
+++ b/examples/changing_text_with_fade_transition.py
@@ -14,7 +14,7 @@ class TestApp(App):
     def on_start(self):
         async def main_task(label):
             from kivy.utils import get_random_color
-            await ak.sleep(1)
+            await ak.n_frames(4)
             for text in (
                 'Zen of Python',
                 'Beautiful is better than ugly.',

--- a/examples/using_interpolate.py
+++ b/examples/using_interpolate.py
@@ -14,8 +14,7 @@ class TestApp(App):
 
     def on_start(self):
         async def animate_label(label):
-            await ak.sleep(0)
-            await ak.sleep(1)
+            await ak.n_frames(4)
             async for font_size in ak.interpolate(
                     start=0, end=300, d=5, s=.1, t='out_cubic'):
                 label.font_size = font_size

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_sleep():
     import time
     from kivy.clock import Clock
@@ -84,6 +86,5 @@ def test_n_frames_zero():
 
 def test_n_frames_negative_number():
     import asynckivy as ak
-
-    task = ak.start(ak.n_frames(-2))
-    assert task.done
+    with pytest.raises(ValueError):
+        ak.start(ak.n_frames(-2))

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -60,3 +60,30 @@ def test_create_sleep():
     time.sleep(.5)
     Clock.tick()
     assert task_state == 'C'
+
+
+def test_n_frames():
+    from kivy.clock import Clock
+    import asynckivy as ak
+
+    task = ak.start(ak.n_frames(3))
+    Clock.tick()
+    assert not task.done
+    Clock.tick()
+    assert not task.done
+    Clock.tick()
+    assert task.done
+
+
+def test_n_frames_zero():
+    import asynckivy as ak
+
+    task = ak.start(ak.n_frames(0))
+    assert task.done
+
+
+def test_n_frames_negative_number():
+    import asynckivy as ak
+
+    task = ak.start(ak.n_frames(-2))
+    assert task.done


### PR DESCRIPTION
We already can wait for arbitrary number of frames by doing:

```python
for __ in range(N):
    await asynckivy.sleep(0)
```

but this probably is ineffeciant because it internally creates a ClockEvent N times. You can avoid that by doing:

```python
await asynckivy.n_frames(N)
```

which only creates one ClockEvent no matter how the number is bigger. Further more, it's easier to read (well, "easier to read" is the main reason of the PR).