### PR TITLE
optimize 'sleep()' by removing keyword-arguments and closures

### DIFF
--- a/asynckivy/_sleep.py
+++ b/asynckivy/_sleep.py
@@ -10,16 +10,14 @@ create_trigger_free = getattr(Clock, 'create_trigger_free', None)
 
 @types.coroutine
 def sleep(duration):
-    args, kwargs = yield lambda step_coro: \
-        create_trigger(step_coro, duration, release_ref=False)()
+    args, kwargs = yield lambda step_coro, _d=duration: create_trigger(step_coro, _d, False, False)()
     return args[0]
 
 
 @types.coroutine
 def sleep_free(duration):
     '''(experimental)'''
-    args, kwargs = yield lambda step_coro: \
-        create_trigger_free(step_coro, duration, release_ref=False)()
+    args, kwargs = yield lambda step_coro, _d=duration: create_trigger_free(step_coro, _d, False, False)()
     return args[0]
 
 
@@ -56,8 +54,7 @@ async def create_sleep(duration):
             await some_fn()  # OK
     '''
     from asyncgui import get_step_coro
-    clock_event = Clock.create_trigger(
-        await get_step_coro(), duration, release_ref=False)
+    clock_event = Clock.create_trigger(await get_step_coro(), duration, False, False)
 
     @types.coroutine
     def sleep():

--- a/examples/misc/speed_comparision_between_various_sleep_implementations.py
+++ b/examples/misc/speed_comparision_between_various_sleep_implementations.py
@@ -1,0 +1,87 @@
+from kivy.config import Config
+Config.set('graphics', 'maxfps', 0)
+from kivy.clock import Clock
+from kivy.app import App
+from kivy.lang import Builder
+import asynckivy as ak
+
+import types
+
+KV_CODE = '''
+<MyToggleButton@ToggleButton>:
+    group: 'aaa'
+    on_press: if self.state == 'down': app.measure_fps(self.text)
+
+BoxLayout:
+    orientation: 'vertical'
+    padding: 10
+    spacing: 10
+    MyToggleButton:
+        text: 'original'
+    MyToggleButton:
+        text: 'new1'
+    MyToggleButton:
+        text: 'new2'
+'''
+
+create_trigger = Clock.create_trigger
+
+
+@types.coroutine
+def sleep_original(duration):
+    args, kwargs = yield lambda step_coro: create_trigger(step_coro, duration, release_ref=False)()
+    return args[0]
+
+
+@types.coroutine
+def sleep_new1(duration):
+    '''removed CALL_FUNCTION_KW'''
+    args, kwargs = yield lambda step_coro: create_trigger(step_coro, duration, False, False)()
+    return args[0]
+
+
+@types.coroutine
+def sleep_new2(duration):
+    '''removed closure'''
+    args, kwargs = yield lambda step_coro, _d=duration: create_trigger(step_coro, _d, False, False)()
+    return args[0]
+
+
+def print_byte_code():
+    from dis import dis
+    for key, obj in globals().items():
+        if not key.startswith("sleep_"):
+            continue
+        print("---- byte code ----", key)
+        dis(obj)
+        print("\n\n")
+
+
+print_byte_code()
+
+
+async def repeat_sleep(sleep):
+    while True:
+        await sleep(0)
+
+
+class SampleApp(App):
+    def build(self):
+        self._tasks = []
+        return Builder.load_string(KV_CODE)
+
+    def on_start(self):
+        def print_fps(dt):
+            print(Clock.get_fps(), 'fps')
+        Clock.schedule_interval(print_fps, 1)
+
+    def measure_fps(self, type):
+        print('---- start measuring ----', type)
+        sleep = globals()['sleep_' + type]
+        for task in self._tasks:
+            task.cancel()
+        self._tasks = [ak.start(repeat_sleep(sleep)) for __ in range(10)]
+
+
+if __name__ == '__main__':
+    SampleApp().run()


### PR DESCRIPTION
### Difference of bytecode (CPython 3.8.12)

```diff
-  0 LOAD_CLOSURE             0 (duration)
+  0 LOAD_FAST                0 (duration)
 2 BUILD_TUPLE              1
 4 LOAD_CONST               1 (<code object <lambda> ...)
 6 LOAD_CONST               2 ('sleep_original.<locals>.<lambda>')
-  8 MAKE_FUNCTION            8 (closure)
+  8 MAKE_FUNCTION            1 (defaults)
10 YIELD_VALUE
12 UNPACK_SEQUENCE          2
14 STORE_FAST               1 (args)
16 STORE_FAST               2 (kwargs)

18 LOAD_FAST                1 (args)
20 LOAD_CONST               3 (0)
22 BINARY_SUBSCR
24 RETURN_VALUE

Disassembly of <code object <lambda> at ...>:
 0 LOAD_GLOBAL              0 (create_trigger)
 2 LOAD_FAST                0 (step_coro)
-  4 LOAD_DEREF               0 (duration)
+  4 LOAD_FAST                1 (_d)
 6 LOAD_CONST               1 (False)
-  8 LOAD_CONST               2 (('release_ref',))
- 10 CALL_FUNCTION_KW         3
+  8 LOAD_CONST               1 (False)
+ 10 CALL_FUNCTION            4
12 CALL_FUNCTION            0
14 RETURN_VALUE
```

### Fps comparison

`examples/misc/speed_comparision_between_various_sleep_implementations.py` outputs:

```
---- start measuring ---- original
10111.412729161024 fps
10218.91297572801 fps
10247.353617432778 fps
10242.177163963104 fps
10342.040568912495 fps
10349.013542367311 fps
10353.113721708287 fps
10211.658113679834 fps
10234.56141833754 fps
10245.324812616254 fps
---- start measuring ---- new2
10295.506587853904 fps
10303.670303148883 fps
10439.380328829831 fps
10459.800531591893 fps
10430.90984565568 fps
10439.31085933859 fps
10404.521173518033 fps
10413.352060412866 fps
10439.457273500058 fps
10510.90077709443 fps
```

As you can see, `new2` is faster than the `original` (at least on my end). Not sure how much faster though.