### PR TITLE
refactor animation-related unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,23 +2,23 @@ import pytest
 from kivy.tests.fixtures import kivy_clock
 
 
-@pytest.fixture()
-def ready_to_sleep():
+@pytest.fixture(scope='session')
+def _sleep_then_tick():
+    from functools import partial
     from kivy.clock import Clock
-    from time import time, sleep
+    import time 
 
-    last = None
+    def f(time_sleep, clock_time, clock_get_time, clock_tick, duration):
+        # clock_get_time() returns the last time the clock ticked.
+        # clock_time() returns the current time.
+        time_sleep(clock_get_time() + duration - clock_time())
+        clock_tick()
 
-    def sleep_then_tick(duration):
-        nonlocal last
-        last += duration
-        sleep(last - time())
-        Clock.tick()
+    return partial(f, time.sleep, Clock.time, Clock.get_time, Clock.tick)
 
-    def ready_to_sleep():
-        nonlocal last
-        Clock.tick()
-        last = time()
-        return sleep_then_tick
 
-    return ready_to_sleep
+@pytest.fixture()
+def sleep_then_tick(_sleep_then_tick):
+    from kivy.clock import Clock
+    Clock.tick()
+    return _sleep_then_tick

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -7,61 +7,99 @@ def approx():
     return partial(pytest.approx, abs=1)
 
 
-class Target:
-    def __init__(self):
-        self.num = 0
-        self.lst = [0, 0, ]
-        self.dct = {'key': 0, }
-
-
-def test_cancel(approx, ready_to_sleep):
+def test_scalar(approx, sleep_then_tick):
+    from types import SimpleNamespace
     import asynckivy as ak
-    target = Target()
-    coro = ak.animate(target, num=100, d=.4,)
-    sleep = ready_to_sleep()
-    ak.raw_start(coro)
 
-    sleep(.1)
-    assert target.num == approx(25)
-    sleep(.1)
-    assert target.num == approx(50)
-    coro.close()  # cancel
-    assert target.num == approx(50)
+    obj = SimpleNamespace(num=0)
+    task = ak.start(ak.animate(obj, num=100, d=.4))
+
+    sleep_then_tick(.1)
+    assert obj.num == approx(25)
+    sleep_then_tick(.1)
+    assert obj.num == approx(50)
+    sleep_then_tick(.1)
+    assert obj.num == approx(75)
+    sleep_then_tick(.1)
+    assert obj.num == approx(100)
+    sleep_then_tick(.1)
+    assert obj.num == approx(100)
+    assert task.done
 
 
-def test_list(approx, ready_to_sleep):
+def test_list(approx, sleep_then_tick):
+    from types import SimpleNamespace
     import asynckivy as ak
-    target = Target()
-    coro = ak.animate(target, lst=[100, 200], d=.4)
-    sleep = ready_to_sleep()
-    ak.start(coro)
 
-    sleep(.1)
-    assert target.lst == approx([25, 50])
-    sleep(.1)
-    assert target.lst == approx([50, 100])
-    sleep(.1)
-    assert target.lst == approx([75, 150])
-    sleep(.1)
-    assert target.lst == approx([100, 200])
-    sleep(.1)
-    assert target.lst == approx([100, 200])
+    obj = SimpleNamespace(list=[0, 0])
+    task = ak.start(ak.animate(obj, list=[100, 200], d=.4))
+
+    sleep_then_tick(.1)
+    assert obj.list == approx([25, 50])
+    sleep_then_tick(.1)
+    assert obj.list == approx([50, 100])
+    sleep_then_tick(.1)
+    assert obj.list == approx([75, 150])
+    sleep_then_tick(.1)
+    assert obj.list == approx([100, 200])
+    sleep_then_tick(.1)
+    assert obj.list == approx([100, 200])
+    assert task.done
 
 
-def test_dict(approx, ready_to_sleep):
+def test_dict(approx, sleep_then_tick):
+    from types import SimpleNamespace
     import asynckivy as ak
-    target = Target()
-    coro = ak.animate(target, dct={'key': 100}, d=.4)
-    sleep = ready_to_sleep()
-    ak.start(coro)
 
-    sleep(.1)
-    assert target.dct == approx({'key': 25})
-    sleep(.1)
-    assert target.dct == approx({'key': 50})
-    sleep(.1)
-    assert target.dct == approx({'key': 75})
-    sleep(.1)
-    assert target.dct == approx({'key': 100})
-    sleep(.1)
-    assert target.dct == approx({'key': 100})
+    obj = SimpleNamespace(dict={'key': 0., })
+    task = ak.start(ak.animate(obj, dict={'key': 100}, d=.4))
+
+    sleep_then_tick(.1)
+    assert obj.dict == approx({'key': 25})
+    sleep_then_tick(.1)
+    assert obj.dict == approx({'key': 50})
+    sleep_then_tick(.1)
+    assert obj.dict == approx({'key': 75})
+    sleep_then_tick(.1)
+    assert obj.dict == approx({'key': 100})
+    sleep_then_tick(.1)
+    assert obj.dict == approx({'key': 100})
+    assert task.done
+
+
+def test_cancel(approx, sleep_then_tick):
+    from types import SimpleNamespace
+    import asynckivy as ak
+
+    obj = SimpleNamespace(num=0)
+    task = ak.start(ak.animate(obj, num=100, d=.4,))
+
+    sleep_then_tick(.1)
+    assert obj.num == approx(25)
+    sleep_then_tick(.1)
+    assert obj.num == approx(50)
+    task.cancel()
+    sleep_then_tick(.1)
+    assert obj.num == approx(50)
+
+
+def test_low_fps(approx, sleep_then_tick):
+    from types import SimpleNamespace
+    import asynckivy as ak
+
+    obj = SimpleNamespace(num=0)
+    task = ak.start(ak.animate(obj, num=100, d=.4, step=.3))
+
+    sleep_then_tick(.1)
+    assert obj.num == 0
+    sleep_then_tick(.1)
+    assert obj.num == 0
+    sleep_then_tick(.1)
+    assert obj.num == approx(75)
+    sleep_then_tick(.1)
+    assert obj.num == approx(75)
+    sleep_then_tick(.1)
+    assert obj.num == approx(75)
+    sleep_then_tick(.1)
+    assert obj.num == approx(100)
+    assert task.done

--- a/tests/test_fade_transition.py
+++ b/tests/test_fade_transition.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+@pytest.fixture(scope='module')
+def approx():
+    from functools import partial
+    return partial(pytest.approx, abs=0.01)
+
+
 def test_invalid_argument():
     import asynckivy as ak
     async def job():
@@ -10,53 +16,49 @@ def test_invalid_argument():
         ak.start(job())
 
 
-def test_run_normally(ready_to_sleep):
-    from functools import partial
-    from kivy.uix.widget import Widget
+def test_run_normally(approx, sleep_then_tick):
+    from types import SimpleNamespace
     import asynckivy as ak
-    approx = partial(pytest.approx, rel=0.01)
 
     async def job(w1, w2):
         async with ak.fade_transition(w1, w2):
             pass
 
-    w1 = Widget(opacity=1)
-    w2 = Widget(opacity=2)
-    sleep = ready_to_sleep()
+    w1 = SimpleNamespace(opacity=1)
+    w2 = SimpleNamespace(opacity=2)
     task = ak.start(job(w1, w2))
-    sleep(.1)
+    sleep_then_tick(.1)
     assert w1.opacity == approx(.8)
     assert w2.opacity == approx(1.6)
-    sleep(.4)
-    assert w1.opacity == pytest.approx(0, abs=0.01)
-    assert w2.opacity == pytest.approx(0, abs=0.01)
-    sleep(.1)
+    sleep_then_tick(.4)
+    assert w1.opacity == approx(0)
+    assert w2.opacity == approx(0)
+    sleep_then_tick(.1)
     assert w1.opacity == approx(.2)
     assert w2.opacity == approx(.4)
-    sleep(.4)
+    sleep_then_tick(.4)
     assert w1.opacity == approx(1)
     assert w2.opacity == approx(2)
-    sleep(.2)
+    sleep_then_tick(.2)
     assert w1.opacity == 1
     assert w2.opacity == 2
     assert task.done
 
 
-def test_cancel(ready_to_sleep):
-    from kivy.uix.widget import Widget
+def test_cancel(approx, sleep_then_tick):
+    from types import SimpleNamespace
     import asynckivy as ak
 
     async def job(w1, w2):
         async with ak.fade_transition(w1, w2):
             pass
 
-    w1 = Widget(opacity=1)
-    w2 = Widget(opacity=2)
-    sleep = ready_to_sleep()
+    w1 = SimpleNamespace(opacity=1)
+    w2 = SimpleNamespace(opacity=2)
     task = ak.start(job(w1, w2))
-    sleep(.1)
-    assert w1.opacity != 1
-    assert w2.opacity != 2
+    sleep_then_tick(.1)
+    assert w1.opacity == approx(.8)
+    assert w2.opacity == approx(1.6)
     task.cancel()
     assert w1.opacity == 1
     assert w2.opacity == 2

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -4,42 +4,36 @@ import pytest
 @pytest.fixture(scope='module')
 def approx():
     from functools import partial
-    return partial(pytest.approx, abs=2)
+    return partial(pytest.approx, abs=1)
 
 
-def test_complete_iteration(approx, ready_to_sleep):
+def test_complete_the_iteration(approx, sleep_then_tick):
     import asynckivy as ak
 
     async def job():
-        l = [v async for v in ak.interpolate(start=0, end=100, step=.3)]
+        l = [v async for v in ak.interpolate(start=0, end=100)]
         assert l == approx([0, 30, 60, 90, 100])
 
-    sleep = ready_to_sleep()
     task = ak.start(job())
-    for __ in range(130):
-        sleep(.01)
+    for __ in range(4):
+        sleep_then_tick(.3)
     assert task.done
 
 
-def test_break_during_iteration(approx, ready_to_sleep):
+def test_break_during_the_iteration(approx, sleep_then_tick):
     import asynckivy as ak
 
     async def job():
         l = []
-        async for v in ak.interpolate(start=0, end=100, step=.3):
+        async for v in ak.interpolate(start=0, end=100):
             l.append(v)
             if v > 50:
                 break
         assert l == approx([0, 30, 60, ])
-        await ak.sleep_forever()
 
-    sleep = ready_to_sleep()
     task = ak.start(job())
-    for __ in range(130):
-        sleep(.01)
-    assert not task.done
-    with pytest.raises(StopIteration):
-        task.root_coro.send(None)
+    for __ in range(2):
+        sleep_then_tick(.3)
     assert task.done
 
 
@@ -47,7 +41,7 @@ def test_zero_duration(approx):
     import asynckivy as ak
 
     async def job():
-        l = [v async for v in ak.interpolate(start=0, end=100, step=.3, d=0)]
+        l = [v async for v in ak.interpolate(start=0, end=100, d=0)]
         assert l == approx([0, 100])
 
     task = ak.start(job())


### PR DESCRIPTION
## 主な変更

- animationの対象として`Widget`ではなくより軽い`types.SimpleNamespace`を用いる
- 最後に`Clock.tick()`が呼ばれた時刻を`Clock.get_time()`が返してくれるので、それを利用してより精密な時間`time.sleep()`
- `pytest.approx()`の許容誤差を狭める